### PR TITLE
feat: Add NAI Diffusion 4.5 models

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -40,7 +40,7 @@ class ModelOption:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model": (["nai-diffusion-2", "nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated"], { "default": "nai-diffusion-4-5-curated" }),
+                "model": (["nai-diffusion-2", "nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated", "nai-diffusion-4-5-full"], { "default": "nai-diffusion-4-5-full" }),
             },
             "optional": { "option": ("NAID_OPTION",) },
         }
@@ -256,7 +256,7 @@ class GenerateNAID:
         retry = option["retry"] if option and "retry" in option else None
 
         if limit_opus_free:
-            pixel_limit = 1024*1024 if model in ("nai-diffusion-2", "nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated") else 640*640
+            pixel_limit = 1024*1024 if model in ("nai-diffusion-2", "nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated", "nai-diffusion-4-5-full") else 640*640
             if width * height > pixel_limit:
                 max_width, max_height = calculate_resolution(pixel_limit, (width, height))
                 params["width"] = max_width
@@ -267,10 +267,10 @@ class GenerateNAID:
         if variety:
             params["skip_cfg_above_sigma"] = calculate_skip_cfg_above_sigma(params["width"], params["height"])
 
-        if sampler == "ddim" and model in ("nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated"):
+        if sampler == "ddim" and model in ("nai-diffusion-furry-3", "nai-diffusion-3", "nai-diffusion-4-curated-preview", "nai-diffusion-4-full", "nai-diffusion-4-5-curated", "nai-diffusion-4-5-full"):
             params["sampler"] = "ddim_v3"
 
-        if action == "infill" and model != "nai-diffusion-4-5-curated":
+        if action == "infill" and model != "nai-diffusion-4-5-full":
             model = f"{model}-inpainting"
 
         image = blank_image()


### PR DESCRIPTION
This PR introduces support for the new NovelAI Diffusion 4.5 models:
- `nai-diffusion-4-5-curated`
- `nai-diffusion-4-5-full`

Key changes include:
- Added the new 4.5 models to the `ModelOption` class, setting `nai-diffusion-4-5-full` as the new default.
- Updated the `limit_opus_free` condition in the `GenerateNAID` class to include these new models for pixel limit calculations.
- Ensured the `ddim_v3` sampler is correctly applied when `ddim` is selected with the 4.5 models.
- Updated the logic for appending "-inpainting" to model names for the infill action to correctly handle `nai-diffusion-4-5-full`.